### PR TITLE
Typo in latitude for Aptos Hills-Larkin Valley

### DIFF
--- a/data/1790-2010_MASTER.csv
+++ b/data/1790-2010_MASTER.csv
@@ -7945,7 +7945,7 @@ ID,ST,City,CityST,1790,1800,1810,1820,1830,1840,1850,1860,1870,1880,1890,1900,19
 8548,CA,Angel Island,"Angel Island , CA",,,,,,,0,0,0,305,0,0,0,0,0,0,0,0,0,0,0,0,0,,,Marin,,,37.8630981445312,-122.4293365479,California State Data Center,California State Data Center,,Marin
 8549,CA,Angwin,"Angwin, CA",,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,2690,3526,3503,0,0,,,Napa,,,38.5723800659179,-122.4422302246,California State Data Center,California State Data Center,,Napa
 8550,CA,Aptos,"Aptos, CA",,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,8704,7039,9061,0,0,,,Santa Cruz,,,36.975658416748,-121.8862915039,California State Data Center,California State Data Center,,Santa Cruz
-8551,CA,Aptos Hills-Larkin Valley,"Aptos Hills-Larkin Valley, CA",,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2205,0,0,,,Santa Cruz,,,36.36.960974,-121.833324,California State Data Center,California State Data Center,,Santa Cruz
+8551,CA,Aptos Hills-Larkin Valley,"Aptos Hills-Larkin Valley, CA",,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2205,0,0,,,Santa Cruz,,,36.960974,-121.833324,California State Data Center,California State Data Center,,Santa Cruz
 8552,CA,Aqueduct,"Aqueduct, CA",,,,,,,0,0,0,22,0,0,0,0,0,0,0,0,0,0,0,0,0,,,Amador,,,37.6933403015136,-121.0233230591,California State Data Center,California State Data Center,,Amador
 8553,CA,Arbuckle,"Arbuckle, CA",,,,,,,0,0,0,187,375,1459,0,0,0,0,0,0,1037,1306,1912,0,0,,,Colusa,,,39.0170707702636,-122.0571594238,California State Data Center,California State Data Center,,Colusa
 8554,CA,Armona,"Armona, CA",,,,,,,0,0,0,0,0,0,0,0,0,0,1274,1302,1392,2644,3122,0,0,,,Kings,,,36.313419342041,-119.7090301514,California State Data Center,California State Data Center,,Kings


### PR DESCRIPTION
The latitude was listed as `36.36.960974`.
